### PR TITLE
Connect torque input

### DIFF
--- a/projects/JVRC1/cnoid/sim_mc.py
+++ b/projects/JVRC1/cnoid/sim_mc.py
@@ -127,6 +127,7 @@ def startMCControl():
 
 def connectMCControl():
     connectPorts(rh.port("q"), mc.port("qIn"))
+    connectPorts(rh.port("tauOut"), mc.port("taucIn"))
     connectPorts(rh.port("gyrometer"), mc.port("rateIn"))
     connectPorts(rh.port("gsensor"), mc.port("accIn"))
     connectPorts(rh.port("rfsensor"), mc.port("RightFootForceSensor"))


### PR DESCRIPTION
This MR simply connects the simulated torque to the corresponding input in mc_openrtm.