### PR TITLE
Read floating base groundtruth

### DIFF
--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -58,7 +58,7 @@ namespace
   {
     if(mc_rtc::MC_RTC_VERSION != mc_rtc::version())
     {
-      LOG_ERROR("MCControl was compiled with " << mc_rtc::MC_RTC_VERSION << " but mc_rtc is at version " << mc_rtc::version() << ", you might face subtle issues or unexpected crashes, please recompile mc_openrtm")
+      mc_rtc::log::error("MCControl was compiled with {}  but mc_rtc is at version {}, you might face subtle issues or unexpected crashes, please recompile mc_openrtm", mc_rtc::MC_RTC_VERSION, mc_rtc::version());
     }
     return false;
   }
@@ -111,7 +111,7 @@ MCControl::~MCControl() {}
 
 RTC::ReturnCode_t MCControl::onInitialize()
 {
-  LOG_INFO("MCControl::onInitialize() starting")
+  mc_rtc::log::info("MCControl::onInitialize() starting");
   // Registration: InPort/OutPort/Service
   // <rtc-template block="registration">
   // Set InPort buffers
@@ -156,19 +156,19 @@ RTC::ReturnCode_t MCControl::onInitialize()
   bindParameter("is_enabled", controller.running, "0");
 
   // </rtc-template>
-  LOG_INFO("MCControl::onInitialize() finished")
+  mc_rtc::log::info("MCControl::onInitialize() finished");
   return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t MCControl::onActivated(RTC::UniqueId ec_id)
 {
-  LOG_INFO("onActivated")
+  mc_rtc::log::info("onActivated");
   return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t MCControl::onDeactivated(RTC::UniqueId ec_id)
 {
-  LOG_INFO("onDeactivated")
+  mc_rtc::log::info("onDeactivated");
   return RTC::RTC_OK;
 }
 
@@ -320,7 +320,7 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
       double t = tm.sec * 1e9 + tm.nsec;
       if(!init)
       {
-        LOG_INFO("Init controller")
+        mc_rtc::log::info("Init controller");
         auto q = Eigen::Quaterniond(mc_rbdyn::rpyToMat(rpyIn)).normalized();
         controller.init(qIn, std::array<double, 7>{{q.w(), q.x(), q.y(), q.z(), pIn.x(), pIn.y(), pIn.z()}});
         init = true;

--- a/src/MCControl.h
+++ b/src/MCControl.h
@@ -113,14 +113,14 @@ protected:
   InPort<TimedOrientation3D> m_rpyInIn;
   TimedAngularVelocity3D m_rateIn;
   InPort<TimedAngularVelocity3D> m_rateInIn;
-  Eigen::Vector3d rateIn;
+  Eigen::Vector3d rateIn = Eigen::Vector3d::Zero();
   TimedAcceleration3D m_accIn;
   InPort<TimedAcceleration3D> m_accInIn;
-  Eigen::Vector3d accIn;
+  Eigen::Vector3d accIn = Eigen::Vector3d::Zero();
   TimedPose3D m_poseIn;
   InPort<TimedPose3D> m_poseInIn;
-  Eigen::Vector3d rpyIn;
-  Eigen::Vector3d pIn;
+  Eigen::Vector3d rpyIn = Eigen::Vector3d::Zero();
+  Eigen::Vector3d pIn = Eigen::Vector3d::Zero();
   /* Velocity of the free flyer, given by simulator */
   InPort<TimedDoubleSeq> m_velInIn;
   TimedDoubleSeq m_velIn;
@@ -136,10 +136,10 @@ protected:
   RTC::TimedPose3D m_basePoseIn;
   RTC::TimedDoubleSeq m_baseVelIn;
   RTC::TimedDoubleSeq m_baseAccIn;
-  Eigen::Vector3d floatingBasePosIn;
-  Eigen::Vector3d floatingBaseRPYIn;
-  sva::MotionVecd floatingBaseVelIn;
-  sva::MotionVecd floatingBaseAccIn;
+  Eigen::Vector3d floatingBasePosIn = Eigen::Vector3d::Zero();
+  Eigen::Vector3d floatingBaseRPYIn = Eigen::Vector3d::Zero();
+  sva::MotionVecd floatingBaseVelIn = sva::MotionVecd::Zero();
+  sva::MotionVecd floatingBaseAccIn = sva::MotionVecd::Zero();
 
   std::vector<std::string> m_wrenchesNames;
   std::vector<TimedDoubleSeq *> m_wrenchesIn;

--- a/src/MCControl.h
+++ b/src/MCControl.h
@@ -129,6 +129,18 @@ protected:
   InPort<TimedDoubleSeq> m_taucInIn;
   std::vector<double> taucIn;
 
+  // Floating base input (e.g simulation groundtruth)
+  RTC::InPort<RTC::TimedPose3D> m_basePoseInIn;
+  RTC::InPort<RTC::TimedDoubleSeq> m_baseVelInIn;
+  RTC::InPort<RTC::TimedDoubleSeq> m_baseAccInIn;
+  RTC::TimedPose3D m_basePoseIn;
+  RTC::TimedDoubleSeq m_baseVelIn;
+  RTC::TimedDoubleSeq m_baseAccIn;
+  Eigen::Vector3d floatingBasePosIn;
+  Eigen::Vector3d floatingBaseRPYIn;
+  sva::MotionVecd floatingBaseVelIn;
+  sva::MotionVecd floatingBaseAccIn;
+
   std::vector<std::string> m_wrenchesNames;
   std::vector<TimedDoubleSeq *> m_wrenchesIn;
   std::vector<InPort<TimedDoubleSeq> *> m_wrenchesInIn;

--- a/src/MCControlServiceSVC_impl.h
+++ b/src/MCControlServiceSVC_impl.h
@@ -18,7 +18,7 @@ public:
   MCControlServiceSVC_impl(MCControl * plugin);
   virtual ~MCControlServiceSVC_impl();
 
-  virtual CORBA::Boolean EnableController(const char * name);
+  virtual CORBA::Boolean EnableController(const char * name) override;
 
   /* Grippers (always available) */
   virtual CORBA::Boolean open_grippers() override;


### PR DESCRIPTION
This PR connects the following ports to the "FloatingBase" BodySensor:
- basePoseIn
- baseVelIn
- baseAccIn

This allows reading ground-truth floating base information from choreonoid simulation. 

**Note if you wish to use this for your own robots:**

Everything is set-up for the simulations with the JVRC robot provided with this repository. If you wish to obtain grountruth information for your own robot, you will need the following:

- In `Virtual-YourRobot-RTC.conf`

```
out-port = waistAbsTransform:PELVIS:ABS_TRANSFORM2
out-port = waistAbsVelocity:PELVIS:ABS_VELOCITY
out-port = waistAbsAcceleration:PELVIS:ABS_ACCELERATION
```

- In the simulation script `sim_mc.py`

```
    connectPorts(rh.port("waistAbsTransform"), mc.port("basePoseIn"))
    connectPorts(rh.port("waistAbsVelocity"), mc.port("baseVelIn"))
    connectPorts(rh.port("waistAbsAcceleration"), mc.port("baseAccIn"))
```