### PR TITLE
Let mc_rtc choose how to initialize the base attitude

### DIFF
--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -321,8 +321,7 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
       if(!init)
       {
         mc_rtc::log::info("Init controller");
-        auto q = Eigen::Quaterniond(mc_rbdyn::rpyToMat(rpyIn)).normalized();
-        controller.init(qIn, std::array<double, 7>{{q.w(), q.x(), q.y(), q.z(), pIn.x(), pIn.y(), pIn.z()}});
+        controller.init(qIn);
         init = true;
       }
       if(controller.run())


### PR DESCRIPTION
This PR follows mc_rtc!202 (on gite), and lets `MCGlobalController` choose how to initialize the floating base attitude based on the user configuration.
I'll merge when !202 lands.