### PR TITLE
[CI] Build with clang, proctect inclusion order 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04]
-        compiler: [gcc]
+        compiler: [gcc, clang]
+        build-type: [Release, RelWithDebInfo]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -56,15 +57,15 @@ jobs:
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
       with:
-        compiler: gcc
-        build-type: RelWithDebInfo
+        compiler: ${{matrix.compiler}}
+        build-type: ${{ matrix.build-type }}
         ubuntu: |
           apt: hrpsys-base choreonoid libcnoid-dev libmc-rtc-dev
     - name: Build and test
       uses: jrl-umi3218/github-actions/build-cmake-project@master
       with:
-        compiler: gcc
-        build-type: RelWithDebInfo
+        compiler: ${{ matrix.compiler }}
+        build-type: ${{ matrix.build-type }}
     - name: Slack Notification
       if: failure()
       uses: archive/github-actions-slack@master

--- a/src/MCControl.h
+++ b/src/MCControl.h
@@ -11,6 +11,9 @@
 #ifndef MCCONTROL_H
 #define MCCONTROL_H
 
+// clang-format off
+// Disable clang-format to protect the inclusion order
+// These two headers must come first
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
 
@@ -19,6 +22,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/Manager.h>
+// clang-format on
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">


### PR DESCRIPTION
This PR sets up compilation with clang

Similarely to https://github.com/jrl-umi3218/mc_udp/pull/2, this also protects inclusion order from clang-format, as the inclusion order of openrtm headers matters.