### PR TITLE
[JVRC1] Generate fixed-based variant in the air

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+compile_commands.json

--- a/projects/JVRC1/cnoid/CMakeLists.txt
+++ b/projects/JVRC1/cnoid/CMakeLists.txt
@@ -8,12 +8,21 @@ set(CONFIG_FILES
   sim_mc_wall.in.cnoid
 )
 
+# Generate floating cnoid files for floating base model
+set(JVRC1_MODEL_NAME "main")
 foreach(CFG ${CONFIG_FILES})
   string(REPLACE ".in" "" CFG_OUT "${CFG}")
   configure_file(${CFG} ${CMAKE_CURRENT_BINARY_DIR}/${CFG_OUT} @ONLY)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${CFG_OUT}
     DESTINATION "${HRPSYS_BASE_PREFIX}/share/hrpsys/samples/JVRC1")
 endforeach()
+
+# Generate cnoid files for fixed-based model 
+set(JVRC1_MODEL_NAME "main_fixed")
+configure_file(sim_mc_fixed.in.cnoid ${CMAKE_CURRENT_BINARY_DIR}/sim_mc_fixed.cnoid @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/sim_mc_fixed.cnoid 
+  DESTINATION "${HRPSYS_BASE_PREFIX}/share/hrpsys/samples/JVRC1"
+)
 
 install(FILES
   PDgains_sim.dat

--- a/projects/JVRC1/cnoid/PDcontroller.in.conf.choreonoid
+++ b/projects/JVRC1/cnoid/PDcontroller.in.conf.choreonoid
@@ -3,6 +3,6 @@ exec_cxt.periodic.rate: 1000000
 nStep: 5
 dt: 0.001
 ref_dt: 0.005
-model: file:///@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/main.wrl
+model: file:///@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/@JVRC1_MODEL_NAME@.wrl
 pdgains_sim_file_name: PDgains_sim.dat
 pdcontrol_tlimit_ratio: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1

--- a/projects/JVRC1/cnoid/RobotHardware.in.conf
+++ b/projects/JVRC1/cnoid/RobotHardware.in.conf
@@ -1,4 +1,4 @@
-model: file://@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/main.wrl
+model: file://@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/@JVRC1_MODEL_NAME@.wrl
 sensor_id.right_leg_force_sensor: 0
 sensor_id.left_leg_force_sensor: 1
 exec_cxt.periodic.type: hrpExecutionContext

--- a/projects/JVRC1/cnoid/robot.in.conf
+++ b/projects/JVRC1/cnoid/robot.in.conf
@@ -1,5 +1,5 @@
-model: file://@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/main.wrl
-model_bush: file://@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/main.wrl
+model: file://@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/@JVRC1_MODEL_NAME@.wrl
+model_bush: file://@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/@JVRC1_MODEL_NAME@.wrl
 dt: 0.005
 have_yaskawa_motor: 0
 inertia_sensor_on_trunk: 1

--- a/projects/JVRC1/cnoid/robot.in.py
+++ b/projects/JVRC1/cnoid/robot.in.py
@@ -27,7 +27,7 @@ nshost = "localhost"
 
 modelName = 'JVRC1'
 url = 'file://' + \
-    '@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/main.wrl'
+    '@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/@JVRC1_MODEL_NAME@.wrl'
 
 # pose parameters
 timeToHalfsitPose = 3.0  # [sec]

--- a/projects/JVRC1/cnoid/sim_mc_fixed.in.cnoid
+++ b/projects/JVRC1/cnoid/sim_mc_fixed.in.cnoid
@@ -86,29 +86,6 @@ items:
                     visualRatio: 0.002
         - 
           id: 6
-          name: "longfloor"
-          plugin: Body
-          class: BodyItem
-          data: 
-            modelFile: "@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/sample/model/longfloor.wrl"
-            currentBaseLink: "WAIST"
-            rootPosition: [ 0, 0, -0.1 ]
-            rootAttitude: [ 
-              1, 0, 0, 
-              0, 1, 0, 
-              0, 0, 1 ]
-            jointPositions: [  ]
-            initialRootPosition: [ 0, 0, -0.1 ]
-            initialRootAttitude: [ 
-              1, 0, 0, 
-              0, 1, 0, 
-              0, 0, 1 ]
-            zmp: [ 0, 0, 0 ]
-            collisionDetection: true
-            selfCollisionDetection: false
-            isEditable: true
-        - 
-          id: 7
           name: "AISTSimulator"
           plugin: Body
           class: AISTSimulatorItem
@@ -137,7 +114,7 @@ items:
             2Dmode: false
             oldAccelSensorMode: false
         - 
-          id: 8
+          id: 7
           name: "sim_mc.py"
           plugin: PythonSimScript
           class: PythonSimScriptItem
@@ -157,9 +134,9 @@ views:
     plugin: Base
     class: ItemTreeView
     state: 
-      selected: [ [ 5, "ForceSensor" ], 7 ]
-      checked: [ 3, 4, [ 5, "ForceSensor" ], 6, 8 ]
-      expanded: [ 2, 3, 4, 5, 7 ]
+      selected: [ [ 5, "ForceSensor" ], 6 ]
+      checked: [ 3, 4, [ 5, "ForceSensor" ], 7 ]
+      expanded: [ 2, 3, 4, 5, 6 ]
   - 
     id: 2
     plugin: Base

--- a/projects/JVRC1/cnoid/sim_mc_wall.in.cnoid
+++ b/projects/JVRC1/cnoid/sim_mc_wall.in.cnoid
@@ -29,7 +29,7 @@ items:
           plugin: Body
           class: BodyItem
           data:
-            modelFile: "@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/main.wrl"
+            modelFile: "@OPENHRP3_1_PREFIX@/share/OpenHRP-3.1/robot/JVRC1/@JVRC1_MODEL_NAME@.wrl"
             currentBaseLink: "PELVIS"
             rootPosition: [ -0.0164712421, -0.00366884734, 0.823007651 ]
             rootAttitude: [

--- a/projects/JVRC1/model/CMakeLists.txt
+++ b/projects/JVRC1/model/CMakeLists.txt
@@ -1,3 +1,9 @@
+set(BASE_JOINT_TYPE "free")
+configure_file(JVRC1/main.in.wrl ${CMAKE_CURRENT_BINARY_DIR}/JVRC1/main.wrl)
+
+set(BASE_JOINT_TYPE "fixed")
+configure_file(JVRC1/main.in.wrl ${CMAKE_CURRENT_BINARY_DIR}/JVRC1/main_fixed.wrl)
+
 install(FILES
     JVRC1/Map01_siri.jpg
     JVRC1/Map03_douF.jpg
@@ -34,7 +40,8 @@ install(FILES
     JVRC1/lulittle.wrl
     JVRC1/luthumb.wrl
     JVRC1/lwrist.wrl
-    JVRC1/main.wrl
+    ${CMAKE_CURRENT_BINARY_DIR}/JVRC1/main.wrl
+    ${CMAKE_CURRENT_BINARY_DIR}/JVRC1/main_fixed.wrl
     JVRC1/neck.wrl
     JVRC1/pelvis.wrl
     JVRC1/rankle.wrl

--- a/projects/JVRC1/model/JVRC1/main.in.wrl
+++ b/projects/JVRC1/model/JVRC1/main.in.wrl
@@ -228,7 +228,7 @@ Viewpoint {
 DEF JVRC-1 Humanoid {
   humanoidBody [
     DEF PELVIS Joint {
-      jointType "free"
+      jointType "@BASE_JOINT_TYPE@"
       translation 0 0 0.854
       children [
         DEF PELVIS_S Segment {


### PR DESCRIPTION
Generates:
- a floating-base model `main.wrl` with the Pelvis considered as a `free` joint
- a fixed-base model `main_fixed.wrl` with the Pelvis considered a a `fixed` joint
- `sim_mc_fixed.cnoid` a cnoid dynamic simulation using the fixed robot (robot floating in the air)

This notably allows to run the [force sensor calibration controller](https://gite.lirmm.fr/multi-contact/mc_force_sensor_calibration_controller) in the dynamic simulation.