### PR TITLE
Connect encoderVelocities input

### DIFF
--- a/projects/JVRC1/cnoid/sim_mc.py
+++ b/projects/JVRC1/cnoid/sim_mc.py
@@ -127,6 +127,7 @@ def startMCControl():
 
 def connectMCControl():
     connectPorts(rh.port("q"), mc.port("qIn"))
+    connectPorts(rh.port("dq"), mc.port("alphaIn"))
     connectPorts(rh.port("tauOut"), mc.port("taucIn"))
     connectPorts(rh.port("gyrometer"), mc.port("rateIn"))
     connectPorts(rh.port("gsensor"), mc.port("accIn"))

--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -70,6 +70,7 @@ MCControl::MCControl(RTC::Manager* manager)
     m_timeStep(0.002),
     m_enabled(false),
     m_qInIn("qIn", m_qIn),
+    m_alphaInIn("alphaIn", m_alphaIn),
     m_qInitIn("qInit", m_qInit),
     m_pInIn("pIn", m_pIn),
     m_rpyInIn("rpyIn", m_rpyIn),
@@ -116,6 +117,7 @@ RTC::ReturnCode_t MCControl::onInitialize()
   // <rtc-template block="registration">
   // Set InPort buffers
   addInPort("qIn", m_qInIn);
+  addInPort("alphaIn", m_alphaInIn);
   addInPort("qInit", m_qInitIn);
   addInPort("pIn", m_pInIn);
   addInPort("rpyIn", m_rpyInIn);
@@ -292,6 +294,15 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
       qInit[i] = m_qInit.data[i];
     }
   }
+  if(m_alphaInIn.isNew())
+  {
+    m_alphaInIn.read();
+    alphaIn.resize(m_alphaIn.data.length());
+    for(unsigned int i = 0; i < alphaIn.size(); ++i)
+    {
+      alphaIn[i] = m_alphaIn.data[i];
+    }
+  }
   if(m_qInIn.isNew())
   {
     m_qInIn.read();
@@ -310,6 +321,7 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
     controller.setSensorLinearVelocity(velIn.linear());
     controller.setSensorAcceleration(accIn);
     controller.setEncoderValues(qIn);
+    controller.setEncoderVelocities(alphaIn);
     controller.setWrenches(m_wrenches);
     controller.setJointTorques(taucIn);
 

--- a/src/MCControl.h
+++ b/src/MCControl.h
@@ -108,6 +108,9 @@ protected:
   TimedDoubleSeq m_qIn;
   InPort<TimedDoubleSeq> m_qInIn;
   std::vector<double> qIn;
+  TimedDoubleSeq m_alphaIn;
+  InPort<TimedDoubleSeq> m_alphaInIn;
+  std::vector<double> alphaIn;
   TimedDoubleSeq m_qInit;
   InPort<TimedDoubleSeq> m_qInitIn;
   std::vector<double> qInit = {};


### PR DESCRIPTION
This PR:
- adds an `alphaIn` port to connect encoder velocity readings from simulation/sensor, and set the value of the corresponding `encoderVelocity` sensor.
- connects the corresponding port for the JVRC1 project.

Tested against the finite differences `Encoder` observer results, I'll merge when pipeline succeeds.