### PR TITLE
Use qInit instead of qIn to initialize mc_rtc

### DIFF
--- a/projects/JVRC1/cnoid/sim_mc.py
+++ b/projects/JVRC1/cnoid/sim_mc.py
@@ -126,6 +126,7 @@ def startMCControl():
     mc.setProperty("is_enabled", "1")
 
 def connectMCControl():
+    connectPorts(sh.port("qOut"), mc.port("qInit"))
     connectPorts(rh.port("q"), mc.port("qIn"))
     connectPorts(rh.port("dq"), mc.port("alphaIn"))
     connectPorts(rh.port("tauOut"), mc.port("taucIn"))

--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -348,7 +348,8 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
         }
         else
         {
-          mc_rtc::log::warning("The size of qInit does not mach the size of qIn, please update the corresponding Python script... using qIn instead to initialize the controller");
+          mc_rtc::log::warning("The size of qInit does not mach the size of qIn, please update the corresponding "
+                               "Python script... using qIn instead to initialize the controller");
           controller.init(qIn);
         }
         init = true;

--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -342,7 +342,7 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
       if(!init)
       {
         mc_rtc::log::info("Init controller");
-        controller.init(qIn);
+        controller.init(qInit);
         init = true;
       }
       if(controller.run())

--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -342,7 +342,15 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
       if(!init)
       {
         mc_rtc::log::info("Init controller");
-        controller.init(qInit);
+        if(qInit.size() == qIn.size())
+        {
+          controller.init(qInit);
+        }
+        else
+        {
+          mc_rtc::log::warning("The size of qInit does not mach the size of qIn, please update the corresponding Python script... using qIn instead to initialize the controller");
+          controller.init(qIn);
+        }
         init = true;
       }
       if(controller.run())


### PR DESCRIPTION
i.e. use target commands instead of current encoders values

In all the robots, every time that mc_rtc starts, there is a small sudden motion of the robot (a discontinuity)

This is because the behaviour prior to this commit is to use the current joint angles as desired angles.
However, by doing that, for an instant the torque required by the PD controller will be zero, and the required current will be zero.
Then, an error will have to be created to inject torque once again.
In PD control there is always steady state error.

What was done to solve this problem is to connect the previous command values to qInit and use these ones to initialize mc_rtc