### PR TITLE
Add -f option to rm in clear-omninames.sh

### DIFF
--- a/projects/JVRC1/cnoid/clear-omninames.sh
+++ b/projects/JVRC1/cnoid/clear-omninames.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 sudo /etc/init.d/omniorb4-nameserver stop
-sudo rm /var/log/omniorb-nameserver.log 2> /dev/null
-sudo rm /var/lib/omniorb/* 2> /dev/null
+sudo rm -f /var/log/omniorb-nameserver.log 2> /dev/null
+sudo rm -f /var/lib/omniorb/* 2> /dev/null
 sudo rm -f /tmp/rtcmanager.ref 2> /dev/null
 sudo /etc/init.d/omniorb4-nameserver start
 sleep 1


### PR DESCRIPTION
I got the following error when calling clear-omninames.sh in CI. I hope this PR will resolve this error.
```bash
+ ./clear-omninames.sh
 * Stopping omniORB name server omniNames
   ...done.
 * Starting omniORB name server omniNames
   ...done.
tail: cannot open '/var/log/omniorb-nameserver.log' for reading: No such file or directory
Error: Process completed with exit code 1.
```
CI log: https://github.com/mmurooka/BaselineWalkingController/runs/8114148942?check_suite_focus=true