### PR TITLE
Wait until the omniorb log file is generated in clear-omninames.sh

### DIFF
--- a/projects/JVRC1/cnoid/clear-omninames.sh
+++ b/projects/JVRC1/cnoid/clear-omninames.sh
@@ -5,8 +5,9 @@ sudo rm -f /var/log/omniorb-nameserver.log 2> /dev/null
 sudo rm -f /var/lib/omniorb/* 2> /dev/null
 sudo rm -f /tmp/rtcmanager.ref 2> /dev/null
 sudo /etc/init.d/omniorb4-nameserver start
-until [ -f /var/log/omniorb-nameserver.log ]
+for i in {0..9}
 do
-     sleep 1
+    [ -f /var/log/omniorb-nameserver.log ] && break
+    sleep 1
 done
 tail /var/log/omniorb-nameserver.log

--- a/projects/JVRC1/cnoid/clear-omninames.sh
+++ b/projects/JVRC1/cnoid/clear-omninames.sh
@@ -5,5 +5,8 @@ sudo rm -f /var/log/omniorb-nameserver.log 2> /dev/null
 sudo rm -f /var/lib/omniorb/* 2> /dev/null
 sudo rm -f /tmp/rtcmanager.ref 2> /dev/null
 sudo /etc/init.d/omniorb4-nameserver start
-sleep 1
+until [ -f /var/log/omniorb-nameserver.log ]
+do
+     sleep 1
+done
 tail /var/log/omniorb-nameserver.log


### PR DESCRIPTION
https://github.com/jrl-umi3218/mc_openrtm/pull/19 does not resolve the error described there, and this PR will resolve it.

The last `tail` command in `clear-omninames.sh` is causing an error if the file is not found (I guess that the log file was sometimes not generated within 1sec due to the limited computing resources on the CI), so it should be fixed. Sorry for the simple mistake :sweat:, but I still think the previous PR is not too bad (no need to revert).

With this PR patch, `clear-omninames.sh` will never return in the unlikely event that the omniorb service does not create a log file. Please let me know if you have any problems with this behavior.