### PR TITLE
prevent mismatch issues between mc_rtc timestep and hrpsys timestep

### DIFF
--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -637,6 +637,7 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
         if(!open_iob())
         {
           failed_iob("open_iob", "(mc_openrtm constructor)");
+          mc_rtc::log::error_and_throw<std::runtime_error>("[mc_openrtm] Cannot verify timesteps of IOB and mc-rtc.");
         }
         double iob_ts = get_signal_period() / 1e9;
         if(fabs(iob_ts - controller.controller().timeStep) > 1e-6)
@@ -647,7 +648,8 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
         }
         if(!close_iob())
         {
-          failed_iob("open_iob", "(mc_openrtm constructor)");
+          failed_iob("close_iob", "(mc_openrtm constructor)");
+          mc_rtc::log::error_and_throw<std::runtime_error>("[mc_openrtm] Could not close IOB.");
         }
       }
       if(!init)

--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -143,26 +143,6 @@ MCControl::MCControl(RTC::Manager* manager)
     }
   }
 
-  // confirm mc-rtc timestep is same as IOB timestep
-  if(!m_is_simulation)
-  {
-    if(!open_iob())
-    {
-      failed_iob("open_iob", "(mc_openrtm constructor)");
-    }
-    double iob_ts = get_signal_period() / 1e9;
-    if(fabs(iob_ts - controller.controller().timeStep) > 1e-6)
-    {
-      mc_rtc::log::error_and_throw<std::runtime_error>(
-          "[mc_openrtm] Missmatch between IOB timestep ({}) and mc_rtc ({}).", iob_ts,
-          controller.controller().timeStep);
-    }
-    if(!close_iob())
-    {
-      failed_iob("open_iob", "(mc_openrtm constructor)");
-    }
-  }
-
   // create datastore calls for reading/writing servo pd gains
   controller.controller().datastore().make_call(
       controller.robot().name() + "::GetPDGains",
@@ -651,6 +631,25 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
 
     if(controller.running)
     {
+      // confirm mc-rtc timestep is same as IOB timestep
+      if(!m_is_simulation)
+      {
+        if(!open_iob())
+        {
+          failed_iob("open_iob", "(mc_openrtm constructor)");
+        }
+        double iob_ts = get_signal_period() / 1e9;
+        if(fabs(iob_ts - controller.controller().timeStep) > 1e-6)
+        {
+          mc_rtc::log::error_and_throw<std::runtime_error>(
+              "[mc_openrtm] Missmatch between IOB timestep ({}) and mc_rtc ({}).", iob_ts,
+              controller.controller().timeStep);
+        }
+        if(!close_iob())
+        {
+          failed_iob("open_iob", "(mc_openrtm constructor)");
+        }
+      }
       if(!init)
       {
         mc_rtc::log::info("Init controller");

--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -143,6 +143,18 @@ MCControl::MCControl(RTC::Manager* manager)
     }
   }
 
+  // confirm mc-rtc timestep is same as IOB timestep
+  if(!m_is_simulation)
+  {
+    long iob_ts = get_signal_period();
+    if(fabs(iob_ts / 1e9 - controller.controller().timeStep) > 1e-6)
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>(
+          "[mc_openrtm] Missmatch between IOB timestep ({}) and mc_rtc ({}).", iob_ts,
+          controller.controller().timeStep);
+    }
+  }
+
   // create datastore calls for reading/writing servo pd gains
   controller.controller().datastore().make_call(
       controller.robot().name() + "::GetPDGains",

--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -150,8 +150,8 @@ MCControl::MCControl(RTC::Manager* manager)
     {
       failed_iob("open_iob", "(mc_openrtm constructor)");
     }
-    long iob_ts = get_signal_period();
-    if(fabs(iob_ts / 1e9 - controller.controller().timeStep) > 1e-6)
+    double iob_ts = get_signal_period() / 1e9;
+    if(fabs(iob_ts - controller.controller().timeStep) > 1e-6)
     {
       mc_rtc::log::error_and_throw<std::runtime_error>(
           "[mc_openrtm] Missmatch between IOB timestep ({}) and mc_rtc ({}).", iob_ts,

--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -146,12 +146,20 @@ MCControl::MCControl(RTC::Manager* manager)
   // confirm mc-rtc timestep is same as IOB timestep
   if(!m_is_simulation)
   {
+    if(!open_iob())
+    {
+      failed_iob("open_iob", "(mc_openrtm constructor)");
+    }
     long iob_ts = get_signal_period();
     if(fabs(iob_ts / 1e9 - controller.controller().timeStep) > 1e-6)
     {
       mc_rtc::log::error_and_throw<std::runtime_error>(
           "[mc_openrtm] Missmatch between IOB timestep ({}) and mc_rtc ({}).", iob_ts,
           controller.controller().timeStep);
+    }
+    if(!close_iob())
+    {
+      failed_iob("open_iob", "(mc_openrtm constructor)");
     }
   }
 

--- a/src/MCControl.cpp
+++ b/src/MCControl.cpp
@@ -643,7 +643,7 @@ RTC::ReturnCode_t MCControl::onExecute(RTC::UniqueId ec_id)
         if(fabs(iob_ts - controller.controller().timeStep) > 1e-6)
         {
           mc_rtc::log::error_and_throw<std::runtime_error>(
-              "[mc_openrtm] Missmatch between IOB timestep ({}) and mc_rtc ({}).", iob_ts,
+              "[mc_openrtm] Missmatch between IOB timestep ({}ms) and mc_rtc ({}ms).", iob_ts,
               controller.controller().timeStep);
         }
         if(!close_iob())


### PR DESCRIPTION
Cf. https://github.com/isri-aist/hrp5p-iob/issues/87

@gergondet please check commit: https://github.com/jrl-umi3218/mc_openrtm/pull/27/commits/a65ad4a238dc87bb2af768726b4d6bc2713c097e
Currently I'm not doing anything if `open_iob` has failed.